### PR TITLE
Use resource file to store cache version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ main.css
 .vagrant
 dev.db
 *.retry
+/resources/cache_version

--- a/bust-cache.sh
+++ b/bust-cache.sh
@@ -2,5 +2,4 @@
 
 echo "Busting cache ..."
 
-GIT_REF=$(git rev-parse --short HEAD)
-grep -lR "_version" src resources | xargs sed -i '' s/_version=\.\*\"/_version=${GIT_REF}\"/g
+git rev-parse --short HEAD > resources/cache_version

--- a/src/clj/bild_ord/endpoint/common.clj
+++ b/src/clj/bild_ord/endpoint/common.clj
@@ -1,5 +1,17 @@
 (ns bild-ord.endpoint.common
-  (:require [hiccup.page :refer [html5 include-js include-css]]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as st]
+            [hiccup.page :refer [html5 include-js include-css]]))
+
+(defn current-version []
+  (try
+    (-> "cache_verson" io/resource slurp st/trim-newline)
+    (catch java.lang.IllegalArgumentException e
+      (println "Couldn't read from /resource/cache_version file")
+      "any")))
+
+(defn versioned-resource [path]
+  (str path "?_version=" (current-version)))
 
 (defn page
   "Base page layout"
@@ -12,15 +24,13 @@
      [:link {:rel "apple-touch-icon-precomposed" :href "/favicon-152.png"}]
      (include-css "/css/base.css")
      (include-css
-      (str "/css/main.css?"
-           ))]
+      (versioned-resource "/css/main.css"))]
     [:body
      (when-let [class (:class options)]
        {:class class})
      body
      (include-js
-      (str "/js/main.js?"
-           ))
+      (versioned-resource "/js/main.js"))
      (when (:cljs-main options)
        [:script (str (:cljs-main options) "();")])])))
 


### PR DESCRIPTION
As per our discussion, this puts the cache version number into a file - allowing us to keep changes out of version control.

This ought to be checked in production to ensure the `io/resource` works ok in that context. You might also want to change what happens when the `resource/cache_version` file is missing (e.g. to return a random number/ the current date-time to prevent unintended cache hits).
