### PR TITLE
Update tests

### DIFF
--- a/test/bild_ord/features/fixtures.clj
+++ b/test/bild_ord/features/fixtures.clj
@@ -52,9 +52,9 @@
     (-> (component/system-map
          :app (duct.component.handler/handler-component (:app config))
          :http (ring.component.jetty/jetty-server (:http config))
-         :game-endpoint (duct.component.endpoint/endpoint-component game-endpoint)
-         :user-endpoint (duct.component.endpoint/endpoint-component user-endpoint)
-         :overview-endpoint (duct.component.endpoint/endpoint-component overview-endpoint)
+         :game-endpoint (duct.component.endpoint/endpoint-component (partial game-endpoint nil))
+         :user-endpoint (duct.component.endpoint/endpoint-component (partial user-endpoint nil))
+         :overview-endpoint (duct.component.endpoint/endpoint-component (partial overview-endpoint nil))
          :db (bild-ord.db/db-component (:db config))
          :ragtime (duct.component.ragtime/ragtime (:ragtime config))
          :fixtures (test-fixtures))

--- a/test/bild_ord/features/helper.clj
+++ b/test/bild_ord/features/helper.clj
@@ -51,7 +51,7 @@
 
 (defn type-word [text position]
   (t/input-text (find-input position)
-                text))
+                (str "_" text)))
 
 (defn type-words [& words]
   (doall (map-indexed (fn [i w] (type-word w i)) words)))


### PR DESCRIPTION
Just a couple of commits to bring the test suite up to date.

The endpoint functions have a new arity. This patch passes `nil` for the `ga` argument. It would be nice to remove the google analytics sentinel entirely in dev and test environments...

For some reason the test that typed in the words in the second round was dropping the first character. I've tried to git bisect and find the change that introduced this but it's proven a little tricky. This workaround solves it for now. It might be worth considering a change of web driver anyway as clj-webdriver is no longer being maintained.